### PR TITLE
Fix infinite recursion bug when passing a client

### DIFF
--- a/src/kwery.js
+++ b/src/kwery.js
@@ -12,11 +12,11 @@ function addToKweries(client, queries) {
       continue;
     }
 
-    if (client) {
-      query = (...args) => query(client, ...args);
-    }
+    let queryFn = client
+      ? (...args) => query(client, ...args)
+      : query;
 
-    kweries.set(key, query);
+    kweries.set(key, queryFn);
   }
 }
 
@@ -49,11 +49,11 @@ function addToMutations(client, mutations) {
   for (let key in mutations) {
     let mutation = mutations[key];
 
-    if (client) {
-      mutation = (...args) => mutation(client, ...args);
-    }
+    let mutationFn = client
+      ? (...args) => mutation(client, ...args)
+      : mutation;
 
-    meutasions.set(key, mutation);
+    meutasions.set(key, mutationFn);
   }
 }
 

--- a/src/tests/kwery.test.js
+++ b/src/tests/kwery.test.js
@@ -253,6 +253,22 @@ describe("kwery", () => {
         expect(queries.paginatedRequest).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe("with injected client", () => {
+      let httpClient = {};
+      let queries = {
+        withClient: jest.fn()
+      };
+
+      beforeAll(() => {
+        createKwery({ queries, Vue, client: httpClient });
+      });
+
+      it("calls query function with client and args", () => {
+        query("withClient", [1, 2]);
+        expect(queries.withClient).toHaveBeenCalledWith(httpClient, 1, 2);
+      });
+    });
   });
 
   describe("meutasions", () => {
@@ -421,6 +437,23 @@ describe("kwery", () => {
 
         expect(queryRes.data).toBeUndefined();
         expect(Kwery.store.has(querySym)).toBe(false);
+      });
+    });
+
+
+    describe("with injected client", () => {
+      let httpClient = {};
+      let mutations = {
+        withClient: jest.fn()
+      };
+
+      beforeAll(() => {
+        createKwery({ mutations, Vue, client: httpClient });
+      });
+
+      it("calls mutation function with client and args", () => {
+        client.mutate("withClient", [1, 2]);
+        expect(mutations.withClient).toHaveBeenCalledWith(httpClient, 1, 2);
       });
     });
   });


### PR DESCRIPTION
When passing a client, the binding for the query/mutation function get updated to point to a function that calls itself causing a `Maximum call stack size exceeded` error when the queries and mutations are added.